### PR TITLE
Build: preserve symlinks when copying files.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -43,7 +43,7 @@ for package in ${packages}; do
   fi
   for path in $(apk info --quiet --contents "${package}"); do
     mkdir -p "/distro/${path%/*}"
-    cp "/${path}" "/distro/${path}"
+    cp -P "/${path}" "/distro/${path}"
   done
 done
 


### PR DESCRIPTION
This ensures we don't duplicate files unnecessarily.